### PR TITLE
Ruby 2.7.x でのテストを修正

### DIFF
--- a/spec/lib/blog_notification/last_article_spec.rb
+++ b/spec/lib/blog_notification/last_article_spec.rb
@@ -15,7 +15,7 @@ describe BlogNotification::LastArticle do
 
     let(:last_article) {
       BlogNotification::LastArticle.new(
-        {
+          **{
           title: title,
           url: url,
           last_update: '2018-01-01 00:00:00 +0900',
@@ -32,7 +32,7 @@ describe BlogNotification::LastArticle do
 
   describe '#to_h' do
 
-    let(:last_article) { BlogNotification::LastArticle.new(default_argument) }
+    let(:last_article) { BlogNotification::LastArticle.new(**default_argument) }
 
     it 'return hash' do
       expect(last_article.to_h).to be_a Hash
@@ -53,7 +53,7 @@ describe BlogNotification::LastArticle do
 
   describe '#[]' do
 
-    let(:last_article) { BlogNotification::LastArticle.new(default_argument) }
+    let(:last_article) { BlogNotification::LastArticle.new(**default_argument) }
 
     context 'access with String' do
       it 'access title' do


### PR DESCRIPTION
名前付き引数への Hash での渡しに `**` を付与.